### PR TITLE
Haeun

### DIFF
--- a/src/main/java/com/spring/mydiv/Controller/PersonController.java
+++ b/src/main/java/com/spring/mydiv/Controller/PersonController.java
@@ -58,7 +58,7 @@ public class PersonController {
         }
     }
 
-    @GetMapping("/{userid}/{travelid}/{personid}")
+    @GetMapping("/{userid}/{travelid}/{personid}/personDetail")
     public PersonCreateDto.Detail getPersonToDetailView(@PathVariable("travelid") int travelid,
                                                         @PathVariable("personid") int personid){
         PersonCreateDto.Detail detailView = personService.getPersonToDetailView(personid);

--- a/src/main/java/com/spring/mydiv/Controller/UserController.java
+++ b/src/main/java/com/spring/mydiv/Controller/UserController.java
@@ -60,14 +60,16 @@ public class UserController {
     }
 
     @PostMapping("/{no}/createTravel")
-    public ResponseEntity<PersonDto> joinTravel(@PathVariable int no, @RequestBody Map map){
+    public int joinTravel(@PathVariable int no, @RequestBody Map map){
         String travel_name = map.get("travel_name").toString();
 //        TravelCreateDto.Request travelInfo = new TravelCreateDto.Request(map.get("travel_name").toString());
         TravelCreateDto.Request travelInfo = new TravelCreateDto.Request(travel_name);
         PersonCreateDto.Request request = new PersonCreateDto.Request(
                 userservice.getUserInfo(no),
                 travelservice.createTravel(travelInfo));
-        return ResponseEntity.ok(personservice.createPerson(request, TRUE));
+        if (ResponseEntity.ok(personservice.createPerson(request, TRUE)).getStatusCodeValue() == 200)
+            return request.getTravel().getId().intValue();
+        else return -1;
     }
 
     // 여행을 생성한 user가 여행 자체를 삭제하는 메소드

--- a/src/main/java/com/spring/mydiv/Dto/PersonCreateDto.java
+++ b/src/main/java/com/spring/mydiv/Dto/PersonCreateDto.java
@@ -48,12 +48,14 @@ public class PersonCreateDto {
         private String Name;
         private Boolean Role;
         private Double Difference;
+        private Long UserId;
         public static HomeView fromEntity(Person person) {
             return HomeView.builder()
                     .Id(person.getId())
                     .Name(person.getUser().getName())
                     .Role(person.getRole())
                     .Difference(person.getDifference())
+                    .UserId(person.getUser().getId())
                     .build();
         }
     }

--- a/src/main/java/com/spring/mydiv/Entity/Participant.java
+++ b/src/main/java/com/spring/mydiv/Entity/Participant.java
@@ -26,10 +26,7 @@ public class Participant implements Serializable {
 	private Person person;
 
 	@ManyToOne
-	@JoinColumns({
-			@JoinColumn(name = "event_id", referencedColumnName = "event_id"),
-			@JoinColumn(name = "event_name", referencedColumnName = "event_name")
-	})
+	@JoinColumn(name = "event_id", referencedColumnName = "event_id")
 	private Event event;
 	
 	@Column(name = "participant_eventrole", length = 1)

--- a/src/main/java/com/spring/mydiv/Entity/Person.java
+++ b/src/main/java/com/spring/mydiv/Entity/Person.java
@@ -31,15 +31,11 @@ public class Person implements Serializable {
 	private Long id;
 	
 	@ManyToOne
-	@JoinColumns({
-			@JoinColumn(name = "user_id", referencedColumnName = "user_id"),
-	})
+	@JoinColumn(name = "user_id", referencedColumnName = "user_id")
 	private User user;
 
 	@ManyToOne
-	@JoinColumns({
-			@JoinColumn(name = "travel_id", referencedColumnName = "travel_id"),
-	})
+	@JoinColumn(name = "travel_id", referencedColumnName = "travel_id")
 	private Travel travel;
 	
 	@Column(name = "person_sumsend", nullable = false)

--- a/src/main/java/com/spring/mydiv/Repository/EventRepository.java
+++ b/src/main/java/com/spring/mydiv/Repository/EventRepository.java
@@ -5,13 +5,14 @@ import com.spring.mydiv.Entity.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author 12nov
  */
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    List<Event> findByTravel_Id(Long id);
+    Optional<List<Event>> findByTravel_Id(Long id);
 
     int countByTravel_Id(Long id);
 

--- a/src/main/java/com/spring/mydiv/Repository/PersonRepository.java
+++ b/src/main/java/com/spring/mydiv/Repository/PersonRepository.java
@@ -1,6 +1,7 @@
 package com.spring.mydiv.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.spring.mydiv.Entity.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,7 +18,7 @@ public interface PersonRepository extends JpaRepository<Person, Long> {
 	List<Person> findByUser_Id(@Param(value = "user_id") Long id);
 
 	Person findByTravel_IdAndRole(Long id, Boolean role);
-	List<Person> findByTravel_Id(Long id);
+	Optional<List<Person>> findByTravel_Id(Long id);
 	void deleteByUser_IdAndTravel_Id(Long userid, Long travelid);
 
 	void deleteById(Long id);

--- a/src/main/java/com/spring/mydiv/Service/EventService.java
+++ b/src/main/java/com/spring/mydiv/Service/EventService.java
@@ -47,6 +47,8 @@ public class EventService {
         List<EventCreateDto.HomeView> result = new ArrayList<EventCreateDto.HomeView>();
         for (Event e : list){
             EventCreateDto.HomeView event = EventCreateDto.HomeView.fromEntity(e);
+            Participant payer = participantRepository.findByEvent_IdAndEventRole(event.getId(),true);
+            event.setPayer(payer.getPerson().getUser().getName());
             result.add(event);
         }
         return result;

--- a/src/main/java/com/spring/mydiv/Service/EventService.java
+++ b/src/main/java/com/spring/mydiv/Service/EventService.java
@@ -43,14 +43,17 @@ public class EventService {
     }
 
     public List<EventCreateDto.HomeView> getEventInfoInTravel(int travelId){
-        List<Event> list = eventRepository.findByTravel_Id(Long.valueOf(travelId));
+        Optional<List<Event>> list = eventRepository.findByTravel_Id(Long.valueOf(travelId));
         List<EventCreateDto.HomeView> result = new ArrayList<EventCreateDto.HomeView>();
-        for (Event e : list){
-            EventCreateDto.HomeView event = EventCreateDto.HomeView.fromEntity(e);
-            Participant payer = participantRepository.findByEvent_IdAndEventRole(event.getId(),true);
-            event.setPayer(payer.getPerson().getUser().getName());
-            result.add(event);
-        }
+        list.ifPresent(
+                list_ ->
+                {for (Event e : list_){
+                    EventCreateDto.HomeView event = EventCreateDto.HomeView.fromEntity(e);
+                    Participant payer = participantRepository.findByEvent_IdAndEventRole(event.getId(),true);
+                    event.setPayer(payer.getPerson().getUser().getName());
+                    result.add(event);
+                }}
+        );
         return result;
     }
 

--- a/src/main/java/com/spring/mydiv/Service/PersonService.java
+++ b/src/main/java/com/spring/mydiv/Service/PersonService.java
@@ -60,9 +60,9 @@ public class PersonService {
     }
 
     public List<PersonCreateDto.Simple> getPersonNameInTravel(int travelId){
-        List<Person> list = personRepository.findByTravel_Id(Long.valueOf(travelId));
+        Optional<List<Person>> list = personRepository.findByTravel_Id(Long.valueOf(travelId));
         List<PersonCreateDto.Simple> result = new ArrayList<PersonCreateDto.Simple>();
-        for (Person p : list){
+        for (Person p : list.get()){
             PersonCreateDto.Simple person = PersonCreateDto.Simple.fromEntity(p);
             result.add(person);
         }
@@ -74,12 +74,15 @@ public class PersonService {
     }
 
     public List<PersonCreateDto.HomeView> getPersonInfoInTravel(int travelId){
-        List<Person> list = personRepository.findByTravel_Id(Long.valueOf(travelId));
+        Optional<List<Person>> list = personRepository.findByTravel_Id(Long.valueOf(travelId));
         List<PersonCreateDto.HomeView> result = new ArrayList<PersonCreateDto.HomeView>();
-        for (Person p : list){
-            PersonCreateDto.HomeView person = PersonCreateDto.HomeView.fromEntity(p);
-            result.add(person);
-        }
+        list.ifPresent(
+                list_ ->
+                {for (Person p : list_){
+                    PersonCreateDto.HomeView person = PersonCreateDto.HomeView.fromEntity(p);
+                    result.add(person);
+                }}
+        );
         return result;
     }
 

--- a/src/main/java/com/spring/mydiv/Service/TravelService.java
+++ b/src/main/java/com/spring/mydiv/Service/TravelService.java
@@ -48,12 +48,12 @@ public class TravelService {
     }
     @Transactional
     public void deleteTravel(int travelId){
-        List<Event> eventList = eventRepository.findByTravel_Id(Long.valueOf(travelId));
-        List<Person> personList = personRepository.findByTravel_Id(Long.valueOf(travelId));
-        for(Event event : eventList){
+        Optional<List<Event>> eventList = eventRepository.findByTravel_Id(Long.valueOf(travelId));
+        Optional<List<Person>> personList = personRepository.findByTravel_Id(Long.valueOf(travelId));
+        for(Event event : eventList.get()){
             eventService.deleteEvent(event.getId().intValue());
         }
-        for(Person person : personList){
+        for(Person person : personList.get()){
             personRepository.delete(person);
         }
         travelRepository.deleteById(Long.valueOf(travelId));


### PR DESCRIPTION
- person detail view endpoint 수정 /{userid}/{travelid}/{personid}/personDetail
- parti DB) event name 삭제, entity 외래키 부분 수정
- travel main view, event list에 payer 이름 포함하도록 수정
- travel main view, event & person list가 조회되지 않으면 비어있는 리스트를 보내도록 수정
- createTravel return값 수정(생성 성공시 travel id, 실패 시 -1)
- person detail view, person의 user id도 함께 리턴해주는 것으로 수정