### PR TITLE
Feat: createUser email duplicated error handling

### DIFF
--- a/src/main/java/com/spring/mydiv/Code/ErrorCode.java
+++ b/src/main/java/com/spring/mydiv/Code/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     WRONG_EMAIL(500,"LOGIN-ERR-500","There is no such email information."),
     WRONG_PASSWORD(500, "LOGIN-ERR-500","Invalid password."),
     ALREADY_EXISTED(500, "CREATE-PERSON-ERR-500","have already been invited."),
+    ALREADY_REGISTERED(500, "CREATE-USER-ERR-500","is already registered."),
     CREATE_FAIL(500, "CREATE-ERR-500", "Failed to create entity on request."),
     CREATE_EVENT_FAIL(500, "CREATE-ERR-500", "Failed to create event entity on request."),
     CREATE_PARTICIPANT_FAIL(500, "CREATE-ERR-500", "Failed to create participant entity on request."),

--- a/src/main/java/com/spring/mydiv/Controller/UserController.java
+++ b/src/main/java/com/spring/mydiv/Controller/UserController.java
@@ -37,12 +37,14 @@ public class UserController {
 
     @PostMapping(value = "/Register")
     public ResponseEntity<UserDto.Response> createUser(@RequestBody Map map) {
-        UserDto.Request request = new UserDto.Request(
-                map.get("user_name").toString(),
-                map.get("user_email").toString(),
-                map.get("user_password").toString(),
-                map.get("user_account").toString());
-        return ResponseEntity.ok(userservice.createUser(request));
+        if (!userservice.checkIsEmailRegistered(map.get("user_email").toString())) {
+            UserDto.Request request = new UserDto.Request(
+                    map.get("user_name").toString(),
+                    map.get("user_email").toString(),
+                    map.get("user_password").toString(),
+                    map.get("user_account").toString());
+            return ResponseEntity.ok(userservice.createUser(request));
+        } else throw new DefaultException(ALREADY_REGISTERED);
     }
 
     @PostMapping(value = "/login")

--- a/src/main/java/com/spring/mydiv/Repository/UserRepository.java
+++ b/src/main/java/com/spring/mydiv/Repository/UserRepository.java
@@ -15,6 +15,7 @@ import javax.persistence.PersistenceContext;
  * @author 12nov
  */
 public interface UserRepository extends JpaRepository<User, Long>{
+    boolean existsByEmail(String email);
     Optional<User> findByEmail(String Email);
     Optional<User> findById(Long no);
 //

--- a/src/main/java/com/spring/mydiv/Service/UserService.java
+++ b/src/main/java/com/spring/mydiv/Service/UserService.java
@@ -46,7 +46,9 @@ public class UserService {
         return UserDto.Response.fromEntity(user);
     } //fin
 
-
+    public boolean checkIsEmailRegistered(String email){
+        return userRepository.existsByEmail(email);
+    }
     public int login(UserDto.Login loginUser) {
         int result = 0;
 
@@ -122,3 +124,5 @@ public class UserService {
     }
 
 }
+
+//


### PR DESCRIPTION
회원가입 시 이미 있는 이메일일 경우, common error가 아닌 ALREADY_REGISTERED 리턴. 현재 "is already registered."만 리턴하고 있으므로, 프론트에서 이메일을 함께 리턴해주면 좋을 것 같습니다.